### PR TITLE
Ability to set bucket resolution from client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Bucket = <<"my_bucket">>.
 Metric = <<2, "my", 6, "metric">>.
 Points = lists:seq(1, 10).
 PointsBinary = mmath_bin:from_list(Points).
-{ok, SCon1} = ddb_tcp:send(Metric, Timestamp, PointsB, SCon).
+{ok, SCon1} = ddb_tcp:send(Metric, Timestamp, PointsBinary, SCon).
 ```
 
 A stream connection is not required in order to perform read operations.  In


### PR DESCRIPTION
Additional `stream/4` function to allow the client to set the bucket resolution on stream write.  Wasn't sure how to overcome the duplication between added function and `stream/3` variant.  Also, when a different resolution is set to a pre-existing resolution, an error is not signalled to the client.  This is similar behaviour to when a point is written that cannot `dproto:decode` on write .

Relates to https://github.com/dalmatinerdb/dalmatinerdb/issues/64
